### PR TITLE
Exclude v1.11.10 from bot

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,9 @@ conda_forge_output_validation: true
 bot:
   run_deps_from_wheel: true
   automerge: true
+  version_updates:
+    exclude:
+      - "1.11.10"
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
Follow-up from:
- https://github.com/regro/cf-graph-countyfair/pull/3 and
- https://github.com/regro/cf-graph-countyfair/pull/2

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
